### PR TITLE
fix #2: RESULT_STATE_UNKNOWN undeclared

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.o
+*.so.2
+kadnode
+kadnode-ctl

--- a/src/kad.c
+++ b/src/kad.c
@@ -420,7 +420,7 @@ int kad_lookup_value( const char _query[], IP addr_array[], size_t *addr_num ) {
 		* no results have been found or more than half of the searches lifetime
 		* has expired.
 		*/
-		if( results_entries_count( results, RESULT_STATE_UNKNOWN ) == 0 ||
+		if( results_entries_count( results ) == 0 ||
 			(time_now_sec() - results->start_time) > (MAX_SEARCH_LIFETIME / 2)
 		) {
 			/* Mark search as in progress */


### PR DESCRIPTION
An additional argument was passed to results_entries_count, which prevented compilation. Variable was removed. Additionally a gitignore file was added, to prevent version tracking of binary files.