### PR TITLE
.gitignore: don't track binary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.o
+*.so.2
+kadnode
+kadnode-ctl


### PR DESCRIPTION
Added a .gitignore to make version control easier: Not to versiontrack compilated, binary files.