### PR TITLE
correction from compile warning

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -25,7 +25,7 @@ struct task_t {
 	net_callback *callback;
 };
 
-struct task_t g_tasks[16] = { 0 };
+struct task_t g_tasks[16] = { {0} };
 int g_tasks_num = 0;
 int g_tasks_changed = 1;
 


### PR DESCRIPTION
Just correction from compile warnings:

src/net.c:28:8: warning: missing braces around initializer [-Wmissing-braces]
 struct task_t g_tasks[16] = { 0 };


