### PR TITLE
correction from compile warning

### DIFF
--- a/src/ext-fwd.c
+++ b/src/ext-fwd.c
@@ -81,7 +81,7 @@ void fwd_debug( int fd ) {
 		cur = cur->next;
 	}
 
-	dprintf( fd, " Found %d forwardings.\n", (int)counter );
+	dprintf( fd, " Found %zu forwardings.\n", counter );
 }
 
 void fwd_add( int port, time_t lifetime ) {

--- a/src/ext-fwd.c
+++ b/src/ext-fwd.c
@@ -81,7 +81,7 @@ void fwd_debug( int fd ) {
 		cur = cur->next;
 	}
 
-	dprintf( fd, " Found %d forwardings.\n", counter );
+	dprintf( fd, " Found %d forwardings.\n", (int)counter );
 }
 
 void fwd_add( int port, time_t lifetime ) {


### PR DESCRIPTION
Just correction from compile warnings:

src/ext-fwd.c: In function \u2018fwd_debug\u2019:
src/ext-fwd.c:84:2: warning: format \u2018%d\u2019 expects argument of type \u2018int\u2019, but argument 3 has type \u2018size_t\u2019 [-Wformat=]
  dprintf( fd, " Found %d forwardings.\n", counter );
  ^