### PR TITLE
fix sed command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,4 +123,3 @@ uninstall:
 	-rm $(DESTDIR)/usr/bin/kadnode-ctl
 	-rm $(DESTDIR)/lib/libnss_kadnode.so.2
 	-sed -i -e 's/^\(hosts:.*\)kadnode \(.*\)/\1\2/' $(DESTDIR)/etc/nsswitch.conf 2> /dev/null
-        

--- a/Makefile
+++ b/Makefile
@@ -116,11 +116,11 @@ install:
 	cp build/kadnode $(DESTDIR)/usr/bin/
 	-cp build/kadnode-ctl $(DESTDIR)/usr/bin/
 	-cp build/libnss_kadnode.so.2 $(DESTDIR)/lib/
-	-sed -i -e '/kadnode/!s/^\(hosts:.*\)\s\{1,\}dns\(.*\)/\1 kadnode dns\2/' $(DESTDIR)/etc/nsswitch.conf 2> /dev/null ;  \
+	-sed -i -e '/kadnode/!s/^\(hosts:.*\)\s\{1,\}dns\(.*\)/\1 kadnode dns\2/' $(DESTDIR)/etc/nsswitch.conf 2> /dev/null
 
 uninstall:
 	rm $(DESTDIR)/usr/bin/kadnode
 	-rm $(DESTDIR)/usr/bin/kadnode-ctl
 	-rm $(DESTDIR)/lib/libnss_kadnode.so.2
-	-sed -i -e 's/^\(hosts:.*\)kadnode \(.*\)/\1\2/' $(DESTDIR)/etc/nsswitch.conf 2> /dev/null ; \
+	-sed -i -e 's/^\(hosts:.*\)kadnode \(.*\)/\1\2/' $(DESTDIR)/etc/nsswitch.conf 2> /dev/null
         

--- a/Makefile
+++ b/Makefile
@@ -116,10 +116,14 @@ install:
 	cp build/kadnode $(DESTDIR)/usr/bin/
 	-cp build/kadnode-ctl $(DESTDIR)/usr/bin/
 	-cp build/libnss_kadnode.so.2 $(DESTDIR)/lib/
-	-sed -i -e '/kadnode/!s/^\(hosts:.*\)dns\(.*\)/\1kadnode dns\2/' $(DESTDIR)/etc/nsswitch.conf 2> /dev/null
+	if [ -e $(DESTDIR)/etc/nsswitch.conf ]; then \
+         sed -i -e '/kadnode/!s/^\(hosts:.*\)\s\{1,\}dns\(.*\)/\1 kadnode dns\2/' $(DESTDIR)/etc/nsswitch.conf 2> /dev/null ;  \
+        fi
 
 uninstall:
 	rm $(DESTDIR)/usr/bin/kadnode
 	-rm $(DESTDIR)/usr/bin/kadnode-ctl
 	-rm $(DESTDIR)/lib/libnss_kadnode.so.2
-	-sed -i -e 's/^\(hosts:.*\)kadnode \(.*\)/\1\2/' $(DESTDIR)/etc/nsswitch.conf 2> /dev/null
+	if [ -e $(DESTDIR)/etc/nsswitch.conf ]; then \
+         sed -i -e 's/^\(hosts:.*\)kadnode \(.*\)/\1\2/' $(DESTDIR)/etc/nsswitch.conf 2> /dev/null ; \
+        fi

--- a/Makefile
+++ b/Makefile
@@ -116,14 +116,11 @@ install:
 	cp build/kadnode $(DESTDIR)/usr/bin/
 	-cp build/kadnode-ctl $(DESTDIR)/usr/bin/
 	-cp build/libnss_kadnode.so.2 $(DESTDIR)/lib/
-	if [ -e $(DESTDIR)/etc/nsswitch.conf ]; then \
-         sed -i -e '/kadnode/!s/^\(hosts:.*\)\s\{1,\}dns\(.*\)/\1 kadnode dns\2/' $(DESTDIR)/etc/nsswitch.conf 2> /dev/null ;  \
-        fi
+	-sed -i -e '/kadnode/!s/^\(hosts:.*\)\s\{1,\}dns\(.*\)/\1 kadnode dns\2/' $(DESTDIR)/etc/nsswitch.conf 2> /dev/null ;  \
 
 uninstall:
 	rm $(DESTDIR)/usr/bin/kadnode
 	-rm $(DESTDIR)/usr/bin/kadnode-ctl
 	-rm $(DESTDIR)/lib/libnss_kadnode.so.2
-	if [ -e $(DESTDIR)/etc/nsswitch.conf ]; then \
-         sed -i -e 's/^\(hosts:.*\)kadnode \(.*\)/\1\2/' $(DESTDIR)/etc/nsswitch.conf 2> /dev/null ; \
-        fi
+	-sed -i -e 's/^\(hosts:.*\)kadnode \(.*\)/\1\2/' $(DESTDIR)/etc/nsswitch.conf 2> /dev/null ; \
+        


### PR DESCRIPTION
Fix to resolve two problems:
1. when we have in /etc/nsswitch.conf  'mdns4' word after 'dns'
hosts:          files mdns4_minimal [NOTFOUND=return] dns mdns4

2. when we do 'make install' in fakeroot catalog
sed -i -e '/kadnode/!s/^\(hosts:.*\)dns\(.*\)/\1kadnode dns\2/' .....src/KadNode/debian/kadnode/etc/nsswitch.conf 2> /dev/null
Makefile:116: recipe for target 'install' failed
make[1]: [install] Error 2 (ignored)