### PR TITLE
debian/control libmbedtls-dev, libnatpmp-dev, libminiupnpc-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: kadnode
 Section: net
 Priority: optional
 Maintainer: Moritz Warning <moritzwarning@web.de>
-Build-Depends: debhelper (>=10)
+Build-Depends: debhelper (>=10), libmbedtls-dev, libnatpmp-dev, libminiupnpc-dev
 Standards-Version: 4.1.4
 Homepage: https://github.com/mwarning/kadnode
 
 Package: kadnode
 Architecture: any
-Depends: libmbedtls (>=2.4.2) | libmbedtls10 (>=2.4.2) | libmbedtls12 (>=2.4.2) | libmbedtls14, ${shlibs:Depends}, ${misc:Depends}, ${misc:Pre-Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${misc:Pre-Depends}
 Description: decentralized DynDNS alternative
  KadNode is a P2P DNS resolver that intercepts system requests for the
  p2p TLD. The decentralized BitTorrent DHT network is network is used

--- a/debian/rules
+++ b/debian/rules
@@ -2,7 +2,7 @@
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
-export FEATURES="tls bob lpd cmd nss"
+export FEATURES="dns lpd tls bob cmd nss natpmp upnp"
 
 # https://wiki.debian.org/Multiarch/Implementation#dh.281.29_and_autotools
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)


### PR DESCRIPTION
I checked #112 and it works locally. Thank you.
Still the raw deb packages aren't easy to use so I created an Ubuntu PPA

https://code.launchpad.net/~stokito/+recipe/kadnode-daily

Now to install the KadNode use:
```
sudo add-apt-repository ppa:stokito/kadnode
sudo apt update
sudo apt install kadnode
```

The build was failed because headers missing so in order to fix that please accept the PR.

Also I enabled all features:
```
$ kadnode --version
KadNode v2.3.0 ( bob cmd dns lpd natpmp nss tls upnp )
```