### PR TITLE
Fix lint errors

### DIFF
--- a/src/ext-dns.c
+++ b/src/ext-dns.c
@@ -563,11 +563,11 @@ static void proxy_read_resolv(IP *dst, const char path[])
 {
 	static time_t last_checked = 0;
 	static time_t last_modified = 0;
-	last_checked = gconf->time_now;
 	// Check at most every second
 	if (last_checked == gconf->time_now) {
 		return;
 	}
+    last_checked = gconf->time_now;
 
 	const char *m = "nameserver ";
 	IP addr;

--- a/src/ext-dns.c
+++ b/src/ext-dns.c
@@ -179,7 +179,7 @@ static const char g_names[MAX_ADDR_RECORDS][3] = {
 * Basic memory operations.
 */
 
-static size_t get16bits(const uint8_t** buffer)
+static uint16_t get16bits(const uint8_t** buffer)
 {
 	uint16_t value;
 
@@ -333,12 +333,9 @@ static int dns_decode_msg(struct Message *msg, const uint8_t *buffer)
 			return -1;
 		}
 
-		int qType = get16bits(&buffer);
-		int qClass = get16bits(&buffer);
-
 		msg->question.qName = msg->qName_buffer;
-		msg->question.qType = qType;
-		msg->question.qClass = qClass;
+		msg->question.qType = get16bits(&buffer);
+		msg->question.qClass = get16bits(&buffer);
 		return 1;
 	}
 

--- a/src/ext-dns.c
+++ b/src/ext-dns.c
@@ -587,12 +587,16 @@ static void proxy_read_resolv(IP *dst, const char path[])
 			const char *beg = strstr(buf, m);
 			if (beg == NULL) {
 				// Ignore missing address
-			} else if (addr_parse(&addr, beg + strlen(m), "53", AF_UNSPEC) < 0) {
+			}
+			const char *dns_serv = beg + strlen(m);
+			int addr_parse_rc = addr_parse(&addr, dns_serv, "53", AF_UNSPEC);
+			if (addr_parse_rc < 0) {
 				log_warning("DNS: Failed to read DNS server from %s", path);
 			} else if (addr_is_localhost(&addr)) {
 				// Ignore localhost entries
 			} else {
 				*dst = addr;
+				log_debug("DNS: Pick a DNS server %s from %s", dns_serv, path);
 			}
 		} else {
 			log_warning("DNS: Failed to open %s", path);

--- a/src/ext-libnss.c
+++ b/src/ext-libnss.c
@@ -38,7 +38,7 @@ static int _nss_kadnode_lookup(struct kadnode_nss_response *res, const struct ka
 	const char *path = NSS_PATH;
 	struct timeval tv;
 	int sock;
-	int rc;
+	ssize_t rc;
 
 	sock = socket(AF_LOCAL, SOCK_STREAM, 0);
 	if (sock < 0) {

--- a/src/ext-tls-server.c
+++ b/src/ext-tls-server.c
@@ -112,7 +112,7 @@ static void tls_client_handler(int rc, int sock)
 #ifdef DEBUG
 		if (ret == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED) {
 			char vrfy_buf[512];
-			int flags = mbedtls_ssl_get_verify_result(&g_ssl);
+			uint32_t flags = mbedtls_ssl_get_verify_result(&g_ssl);
 			mbedtls_x509_crt_verify_info(vrfy_buf, sizeof(vrfy_buf), "", flags);
 
 			log_debug("TLS-Server: Verify failed: %s", vrfy_buf);

--- a/src/log.c
+++ b/src/log.c
@@ -28,8 +28,8 @@ const char *log_time()
 	}
 
 	sprintf(buf, "[%8.2f] ",
-		((double) now.tv_sec + 1.0e-9 * now.tv_nsec) -
-		((double) log_start.tv_sec + 1.0e-9 * log_start.tv_nsec)
+		((double) now.tv_sec + 1.0e-9 * (double)now.tv_nsec) -
+		((double) log_start.tv_sec + 1.0e-9 * (double)log_start.tv_nsec)
 	);
 
 	return buf;


### PR DESCRIPTION
I opened the KadNode in JetBrains CLion and it shows quite a lot of C-Tidy warnings and fixed some of them. Please try to open the project too because there is plenty of others remains.

Also the CLion works great only for CMake projects. So I can't debug right from IDE. I'm not sure if it makes sense but maybe you can use the CMake too?

