### PR TITLE
[Fix bug] kadnode.init fix missing newline

### DIFF
--- a/openwrt/kadnode/files/kadnode.init
+++ b/openwrt/kadnode/files/kadnode.init
@@ -14,8 +14,7 @@ boot() {
 
 xappend() {
 	local name="$2" value="$1"
-	OPTS="$OPTS--${name//_/-} ${value//'/\\'}
-"
+	OPTS="$OPTS\n--${name//_/-} ${value//'/\\'}"
 }
 
 append_opts_list() {
@@ -74,7 +73,7 @@ start_instance() {
 		xappend "" "cmd_disable_stdin"
 	fi
 
-	echo "$OPTS" > $CONFIG_FILE
+	echo -e "$OPTS" > $CONFIG_FILE
 
 	procd_open_instance
 	procd_set_param command $PROG


### PR DESCRIPTION
The kadnode doesn't start on OpenWrt because it's generates a file where all options are written into a single line.

We can't store a newline to the OPTS var.
But without the newline config parsing is failed.
The simplest fix is to use | instead of \n but then replace it on printing