### PR TITLE
peers.txt: add libtorrent.org

### DIFF
--- a/misc/peers.txt
+++ b/misc/peers.txt
@@ -2,3 +2,5 @@ bttracker.debian.org:6881
 router.bittorrent.com:6881
 router.utorrent.com:6881
 tracker.openbittorrent.com:80
+dht.transmissionbt.com:6881
+dht.libtorrent.org:25401


### PR DESCRIPTION
The pkdns also has the list of bootsrap nodes https://github.com/pubky/pkdns/blob/master/server/src/bootstrap_nodes.rs#L31C30-L31C44
And it has the libtorrent that the kadNode doesn't.

I searched over github and found also the transmissionbt.com

The problem is that the peers.txt file is then overridden with raw IPs (v4) and the original domains are lost. So if a user switched to ipv6 then it will never connect to a bootstrap node.
The peers file would be better to store into /var/tmp/ which is temp folder on the OpenWrt to avoid erasing NAND flash. In the same time it's not so big and wasting RAM is also not a good idea on a router.