### PR TITLE
Initialize unset default values AFTER load of config

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -672,7 +672,7 @@ static struct gconf_t *conf_alloc(void)
 static void conf_set_defaults(void)
 {
     if (gconf->af == -1) {
-        gconf->af = AF_UNSPEC;
+        gconf->af = AF_UNSPEC; // both IPv4 and IPv6
     }
 
     if (gconf->dht_port == -1) {
@@ -711,13 +711,13 @@ bool conf_setup(int argc, char **argv)
         }
     }
 
-    conf_set_defaults();
-
     if (gconf->configfile) {
         if (!conf_load_file(gconf->configfile)) {
             return false;
         }
     }
+
+    conf_set_defaults();
 
     return true;
 }


### PR DESCRIPTION
when the KadNode is started from systemd it has the `--config`. But before the config load we call the `conf_set_defaults`:

```c
static void conf_set_defaults(void)
{
    if (gconf->af == -1) {
        gconf->af = AF_UNSPEC; // AF_UNSPEC is 0 i.e. both IPv4 and IPv6
    }
}
```

So the `gconf->af` is set to 0 `AF_UNSPEC`.

And only then the config is loaded. If it has the `--ipv6` or `--ipv4` option then it fails because the `af` is not `-1`:
```c
    case oIpv4:
    case oIpv6:
        if (gconf->af != -1) {
            log_error("Network mode already set: %s", opt);
            return false;
        }
```

Fix #133