### PR TITLE
ext-bob: Fix parse key

### DIFF
--- a/src/ext-bob.c
+++ b/src/ext-bob.c
@@ -194,7 +194,7 @@ void bob_trigger_auth(void)
         compressed[0] = 0x02;
 
         log_info("bob: query=%s", query);
-        if (parse_key_from_query(compressed + 1, sizeof(compressed) - 1, query, strlen(query))) {
+        if (!parse_key_from_query(compressed + 1, sizeof(compressed) - 1, query, strlen(query))) {
             log_error("BOB: Failed to parse query: %s", query);
             bob_auth_end(resource, AUTH_ERROR);
             return;

--- a/src/main.h
+++ b/src/main.h
@@ -4,7 +4,7 @@
 
 
 #define PROGRAM_NAME "kadnode"
-#define PROGRAM_VERSION "2.4.2"
+#define PROGRAM_VERSION "2.4.3"
 
 #define ID_BINARY_LENGTH 20
 #define ID_BASE16_LENGTH 40


### PR DESCRIPTION
In `bob_trigger_auth()`, the condition around `parse_key_from_query()` was inverted: a successfully decoded BOB key was treated as a parse failure, so every BOB lookup stopped with `BOB: Failed to parse query` before UDP verification could run.

## Before fix (kadnode 2.4.2)


```bash
> ping -c 2 -W 3 kmp0dz0aw57dmxynvka7mqy60eggedqvpcby9jregk3d9n2skt90.p2p
ping: kmp0dz0aw57dmxynvka7mqy60eggedqvpcby9jregk3d9n2skt90.p2p: Name or service not known

> journalctl -u kadnode --no-pager 
Jun 25 21:23:04 rpi-v3 kadnode[12555]: Loaded /srv/config/config/kadnode_bob_secret.pem (Public key: kmp0dz0aw57dmxynvka7mqy60eggedqvpcby9jregk3d9n2skt90)
Jun 25 21:23:04 rpi-v3 kadnode[12555]: Starting kadnode 2.4.1 ( bob cmd dns lpd nss tls )
Jun 25 21:23:04 rpi-v3 kadnode[12555]: Net Mode: IPv4+IPv6
Jun 25 21:23:04 rpi-v3 kadnode[12555]: Run Mode: foreground
Jun 25 21:23:04 rpi-v3 kadnode[12555]: Configuration File: /etc/kadnode/kadnode.conf
Jun 25 21:23:04 rpi-v3 kadnode[12555]: Verbosity: verbose
...
Jun 25 21:23:05 rpi-v3 systemd[1]: Started kadnode.service - KadNode P2P DNS resolver.
Jun 25 21:28:57 rpi-v3 kadnode[17381]: BOB: Failed to parse query: kmp0dz0aw57dmxynvka7mqy60eggedqvpcby9jregk3d9n2skt90
Jun 25 21:28:57 rpi-v3 kadnode[17381]: BOB: Failed to parse query: kmp0dz0aw57dmxynvka7mqy60eggedqvpcby9jregk3d9n2skt90
...
```

```bash
> kadnode -v
kadnode 2.4.2 ( bob cmd dns lpd natpmp nss tls upnp )
> getent hosts kmp0dz0aw57dmxynvka7mqy60eggedqvpcby9jregk3d9n2skt90.p2p
> journalctl -u kadnode --no-pager -n 5 --since '1 min ago'
...
Jun 26 01:08:42 rpi-v3 kadnode[50219]: BOB: Failed to parse query: kmp0dz0aw57dmxynvka7mqy60eggedqvpcby9jregk3d9n2skt90
```

## After fix (kadnode 2.4.3)

Version check:
```bash
> kadnode -v
kadnode 2.4.3 ( bob cmd dns lpd natpmp nss tls upnp )
```

```bash
> getent hosts kmp0dz0aw57dmxynvka7mqy60eggedqvpcby9jregk3d9n2skt90.p2p
> journalctl -u kadnode --no-pager -n 5 --since '1 min ago'
-- No entries --
getent exit: 2
-- No entries --
```

(No `BOB: Failed to parse query` in recent logs.)

---

```bash
> ping kmp0dz0aw57dmxynvka7mqy60eggedqvpcby9jregk3d9n2skt90.p2p
ping: kmp0dz0aw57dmxynvka7mqy60eggedqvpcby9jregk3d9n2skt90.p2p: Name or service not known
> journalctl -u kadnode --no-pager -n 5 --since '1 min ago'
-- No entries --
>
```

(No parse errors since 2.4.3 restart.)
