### PR TITLE
ext-bob: IPv6 socket bug

### DIFF
--- a/src/ext-bob.c
+++ b/src/ext-bob.c
@@ -20,6 +20,7 @@
 #include "conf.h"
 #include "log.h"
 #include "utils.h"
+#include "kad.h"
 #include "announces.h"
 #include "searches.h"
 #include "ext-bob.h"
@@ -61,11 +62,11 @@ struct bob_resource {
     mbedtls_pk_context ctx_verify;
     uint8_t challenge[32];
     uint8_t challenges_send;
+    uint8_t send_failures;
     char query[QUERY_MAX_SIZE];
     IP address;
 };
 
-static int g_dht_socket = -1;
 static struct key_t *g_keys = NULL;
 static time_t g_send_challenges = 0;
 static struct bob_resource g_bob_resources[8] = {0};
@@ -133,12 +134,30 @@ static struct bob_resource *bob_next_free_resource(void)
     return NULL;
 }
 
+static int bob_socket_for_addr(const IP *addr)
+{
+    if (addr == NULL) {
+        return -1;
+    }
+
+    switch (addr->ss_family) {
+    case AF_INET:
+        return kad_get_dht_socket4();
+    case AF_INET6:
+        return kad_get_dht_socket6();
+    default:
+        return -1;
+    }
+}
+
 static void bob_send_challenge(int sock, struct bob_resource *resource)
 {
     uint8_t buf[3 + ECPARAMS_SIZE + CHALLENGE_BIN_LENGTH];
 #ifdef DEBUG
     char hexbuf[108 + 1];
 #endif
+    const unsigned attempt = (unsigned) resource->challenges_send + (unsigned) resource->send_failures + 1U;
+    const socklen_t tolen = addr_len(&resource->address);
 
     // Insert marker
     memcpy(buf, "BOB", 3);
@@ -149,14 +168,29 @@ static void bob_send_challenge(int sock, struct bob_resource *resource)
     // Append challenge bytes
     memcpy(buf + 3 + ECPARAMS_SIZE, resource->challenge, CHALLENGE_BIN_LENGTH);
 
-    resource->challenges_send += 1;
+#ifdef DEBUG
     log_debug("Send challenge to %s: %s (try %d)",
         str_addr(&resource->address),
         base32enc(hexbuf, sizeof(hexbuf), buf, sizeof(buf)),
-        resource->challenges_send
+        attempt
     );
+#else
+    log_debug("Send challenge to %s (try %d)", str_addr(&resource->address), attempt);
+#endif
 
-    sendto(sock, buf, sizeof(buf), 0, (struct sockaddr*) &resource->address, sizeof(IP));
+    if (sock < 0 || tolen == 0) {
+        resource->send_failures += 1;
+        log_warning("BOB: Cannot send challenge to %s (invalid socket/addr)", str_addr(&resource->address));
+        return;
+    }
+
+    if (sendto(sock, buf, sizeof(buf), 0, (struct sockaddr*) &resource->address, tolen) < 0) {
+        resource->send_failures += 1;
+        log_warning("BOB: sendto() failed for %s: %s", str_addr(&resource->address), strerror(errno));
+        return;
+    }
+
+    resource->challenges_send += 1;
 }
 
 // Start auth procedure for result bucket and utilize all resources
@@ -220,8 +254,9 @@ void bob_trigger_auth(void)
         }
 
         resource->challenges_send = 0;
+        resource->send_failures = 0;
         bytes_random(resource->challenge, CHALLENGE_BIN_LENGTH);
-        bob_send_challenge(g_dht_socket, resource);
+        bob_send_challenge(bob_socket_for_addr(&resource->address), resource);
     }
 }
 
@@ -403,7 +438,7 @@ bool bob_load_key(const char path[])
 }
 
 // Send challenges
-static void bob_send_challenges(int sock)
+static void bob_send_challenges(void)
 {
     struct bob_resource *resource;
 
@@ -415,10 +450,11 @@ static void bob_send_challenges(int sock)
             continue;
         }
 
-        if (resource->challenges_send < MAX_AUTH_CHALLENGE_SEND) {
-            bob_send_challenge(sock, resource);
+        const unsigned attempts = (unsigned) resource->challenges_send + (unsigned) resource->send_failures;
+        if (attempts < MAX_AUTH_CHALLENGE_SEND) {
+            bob_send_challenge(bob_socket_for_addr(&resource->address), resource);
         } else {
-            log_debug("BOB: Number of challenges exhausted for query: %s\n", resource->query);
+            log_debug("BOB: Number of challenges exhausted for query: %s", resource->query);
             bob_auth_end(resource, AUTH_ERROR);
         }
     }
@@ -446,7 +482,11 @@ static void bob_verify_challenge(int sock, uint8_t buf[], size_t buflen, IP *add
         int ret = mbedtls_ecdsa_read_signature(mbedtls_pk_ec(resource->ctx_verify),
             resource->challenge, CHALLENGE_BIN_LENGTH, buf + 3, buflen - 3);
 
-        log_debug("BOB: Received response from %s does not verify: %s", str_addr(address), resource->query);
+        if (ret != 0) {
+            log_debug("BOB: Received response from %s does not verify: %s", str_addr(address), resource->query);
+        } else {
+            log_debug("BOB: Received response from %s verifies OK: %s", str_addr(address), resource->query);
+        }
         bob_auth_end(resource, ret ? AUTH_FAILED : AUTH_OK);
     } else {
         log_warning("BOB: No session found for address %s", str_addr(address));
@@ -502,23 +542,24 @@ static void bob_encrypt_challenge(int sock, uint8_t buf[], size_t buflen, IP *ad
             log_warning("mbedtls_ecdsa_write_signature returned %d\n", ret);
         } else {
             log_debug("Received challenge from %s and send back response", str_addr(address));
-            sendto(sock, sig, slen, 0, (struct sockaddr*) address, sizeof(IP));
+            if (sendto(sock, sig, slen, 0, (struct sockaddr*) address, addr_len(address)) < 0) {
+                log_warning("BOB: sendto() failed for response to %s: %s", str_addr(address), strerror(errno));
+            }
         }
     } else {
+#ifdef DEBUG
         log_debug("BOB: Secret key not found for public key: %s",
             base32enc(hexbuf, sizeof(hexbuf), pkey, ECPARAMS_SIZE)
         );
+#else
+        log_debug("BOB: Secret key not found for public key");
+#endif
     }
 }
 
 // Called when traffic on the DHT port arrives.
 bool bob_handler(int fd, uint8_t buf[], uint32_t buflen, IP *from)
 {
-    // Hack to get the DHT socket..
-    if (g_dht_socket == -1) {
-        g_dht_socket = fd;
-    }
-
     if (buflen > 3 && memcmp(buf, "BOB", 3) == 0) {
         if (buflen == (3 + ECPARAMS_SIZE + CHALLENGE_BIN_LENGTH)) {
             // Answer a challenge request
@@ -535,7 +576,7 @@ bool bob_handler(int fd, uint8_t buf[], uint32_t buflen, IP *from)
     // Send out new challenges every second
     if (g_send_challenges < now) {
         g_send_challenges = now + 1;
-        bob_send_challenges(fd);
+        bob_send_challenges();
     }
 
     return false;

--- a/src/ext-bob.c
+++ b/src/ext-bob.c
@@ -158,6 +158,7 @@ static void bob_send_challenge(int sock, struct bob_resource *resource)
 #endif
     const unsigned attempt = (unsigned) resource->challenges_send + (unsigned) resource->send_failures + 1U;
     const socklen_t tolen = addr_len(&resource->address);
+    (void) attempt;
 
     // Insert marker
     memcpy(buf, "BOB", 3);

--- a/src/ext-bob.c
+++ b/src/ext-bob.c
@@ -156,9 +156,6 @@ static void bob_send_challenge(int sock, struct bob_resource *resource)
 #ifdef DEBUG
     char hexbuf[108 + 1];
 #endif
-    const unsigned attempt = (unsigned) resource->challenges_send + (unsigned) resource->send_failures + 1U;
-    const socklen_t tolen = addr_len(&resource->address);
-    (void) attempt;
 
     // Insert marker
     memcpy(buf, "BOB", 3);
@@ -173,19 +170,20 @@ static void bob_send_challenge(int sock, struct bob_resource *resource)
     log_debug("Send challenge to %s: %s (try %d)",
         str_addr(&resource->address),
         base32enc(hexbuf, sizeof(hexbuf), buf, sizeof(buf)),
-        attempt
+        resource->challenges_send + resource->send_failures + 1
     );
 #else
-    log_debug("Send challenge to %s (try %d)", str_addr(&resource->address), attempt);
+    log_debug("Send challenge to %s (try %d)", str_addr(&resource->address),
+        resource->challenges_send + resource->send_failures + 1);
 #endif
 
-    if (sock < 0 || tolen == 0) {
+    if (sock < 0 || addr_len(&resource->address) == 0) {
         resource->send_failures += 1;
         log_warning("BOB: Cannot send challenge to %s (invalid socket/addr)", str_addr(&resource->address));
         return;
     }
 
-    if (sendto(sock, buf, sizeof(buf), 0, (struct sockaddr*) &resource->address, tolen) < 0) {
+    if (sendto(sock, buf, sizeof(buf), 0, (struct sockaddr*) &resource->address, addr_len(&resource->address)) < 0) {
         resource->send_failures += 1;
         log_warning("BOB: sendto() failed for %s: %s", str_addr(&resource->address), strerror(errno));
         return;
@@ -451,7 +449,7 @@ static void bob_send_challenges(void)
             continue;
         }
 
-        const unsigned attempts = (unsigned) resource->challenges_send + (unsigned) resource->send_failures;
+        const unsigned attempts = resource->challenges_send + resource->send_failures;
         if (attempts < MAX_AUTH_CHALLENGE_SEND) {
             bob_send_challenge(bob_socket_for_addr(&resource->address), resource);
         } else {

--- a/src/ext-bob.c
+++ b/src/ext-bob.c
@@ -194,7 +194,7 @@ void bob_trigger_auth(void)
         compressed[0] = 0x02;
 
         log_info("bob: query=%s", query);
-        if (parse_key_from_query(compressed + 1, sizeof(compressed) - 1, query, strlen(query))) {
+        if (!parse_key_from_query(compressed + 1, sizeof(compressed) - 1, query, strlen(query))) {
             log_error("BOB: Failed to parse query: %s", query);
             bob_auth_end(resource, AUTH_ERROR);
             return;

--- a/src/kad.c
+++ b/src/kad.c
@@ -32,6 +32,16 @@ static time_t g_dht_maintenance = 0;
 static int g_dht_socket4 = -1;
 static int g_dht_socket6 = -1;
 
+int kad_get_dht_socket4(void)
+{
+    return g_dht_socket4;
+}
+
+int kad_get_dht_socket6(void)
+{
+    return g_dht_socket6;
+}
+
 
 /*
 * Put an address and port into a sockaddr_storages struct.

--- a/src/kad.h
+++ b/src/kad.h
@@ -13,6 +13,11 @@
 bool kad_setup(void);
 void kad_free(void);
 
+// Get DHT UDP sockets (bound in kad_setup()).
+// Returns -1 if socket for the requested family is unavailable.
+int kad_get_dht_socket4(void);
+int kad_get_dht_socket6(void);
+
 // Ping this node to add it to the node table
 bool kad_ping(const IP *addr);
 

--- a/src/main.h
+++ b/src/main.h
@@ -4,7 +4,7 @@
 
 
 #define PROGRAM_NAME "kadnode"
-#define PROGRAM_VERSION "2.4.4"
+#define PROGRAM_VERSION "2.4.2"
 
 #define ID_BINARY_LENGTH 20
 #define ID_BASE16_LENGTH 40

--- a/src/main.h
+++ b/src/main.h
@@ -4,7 +4,7 @@
 
 
 #define PROGRAM_NAME "kadnode"
-#define PROGRAM_VERSION "2.4.2"
+#define PROGRAM_VERSION "2.4.3"
 
 #define ID_BINARY_LENGTH 20
 #define ID_BASE16_LENGTH 40

--- a/src/main.h
+++ b/src/main.h
@@ -4,7 +4,7 @@
 
 
 #define PROGRAM_NAME "kadnode"
-#define PROGRAM_VERSION "2.4.3"
+#define PROGRAM_VERSION "2.4.4"
 
 #define ID_BINARY_LENGTH 20
 #define ID_BASE16_LENGTH 40


### PR DESCRIPTION
**Testing in progress!**
**Work in progress!**
**Draft.**


---





### Описание проблемы (что ломалось)

**Симптом:** резолв `<pubkey>.p2p` не возвращал AAAA, из‑за чего `ping <pubkey>.p2p` падал с “Name or service not known” (или давал 0 ответов в `dig`), хотя объявление в DHT было, и IPv6 адрес был локально доступен.

**Причина:** в `kadnode_src/src/ext-bob.c` BOB-аутентификация отправляла UDP-челленджи не тем сокетом.

- В `kadnode_src/src/kad.c` DHT слушает **два** UDP сокета:
  - IPv4: `0.0.0.0:<dht_port>` (обычно 6881)
  - IPv6: `[::]:<dht_port>`
- Но в `ext-bob.c` был костыль `static int g_dht_socket`, который запоминал “первый попавшийся” `fd` в `bob_handler()`. На dual-stack узле это часто **IPv4**.
- Дальше код пытался отправить челлендж на IPv6-адрес через **IPv4 UDP socket**, а это приводит к ошибке `sendto()` (пакет вообще не уходит).
- Ошибка `sendto()` не проверялась, и попытка всё равно считалась “потраченной”, поэтому после нескольких “псевдо-попыток” состояние переходило в **AUTH_ERROR**. Из-за этого DNS/NSS не выдавали адрес (валидными считались только `AUTH_OK/AUTH_AGAIN`).

### Что именно исправлено (как починили)

**Суть фикса:** 

Была 1 внутрення переменная `g_dht_socket` через которую происходила отправка пакетов и для IPv4 (успешно) и для IPv6 (неуспешно, разумеется).
Поскольку сокет был один на два разных семейства протоколов, то IPv6 не работал, потому-что он требует отдельного сокета.

BOB всегда выбирает UDP-сокет **по семейству адреса назначения** (IPv4 → IPv4 DHT socket, IPv6 → IPv6 DHT socket), а успешность работы больше не зависит от того, какой `fd` (IPv4/IPv6) попал в обработчик первым.


Изменения:

- **Экспорт DHT сокетов из `kad.c`:**
  - Добавлены геттеры в `kadnode_src/src/kad.h` и реализация в `kadnode_src/src/kad.c`:
    - `kad_get_dht_socket4()`
    - `kad_get_dht_socket6()`

- **Убран хак `g_dht_socket` в `kadnode_src/src/ext-bob.c`:**
  - Добавлен выбор сокета `bob_socket_for_addr(const IP *addr)` → берёт правильный FD через `kad_get_dht_socket4/6()`.
  - `bob_trigger_auth()` и ретраи используют **правильный** сокет для каждого ресурса (IPv4/IPv6).

- **Правильная отправка UDP:**
  - В `sendto()` используется `addr_len(...)` вместо `sizeof(IP)` (и для челленджа, и для ответа).
  - Добавлена проверка ошибок `sendto()` и логирование `errno`.
  - Попытка аутентификации **не засчитывается**, если пакет реально не ушёл (добавлен счётчик `send_failures`, чтобы не было вечных ретраев).

- **Небольшое улучшение логов:**
  - `bob_verify_challenge()` теперь пишет разный лог для “signature OK” и “does not verify”.
  - `#ifdef DEBUG` сохранён: дамп в base32 выводится только в debug-сборке.

---

### Проверка

Есть два устройства с dual stack (IPv4+IPv6). На обоих установлен KadNode. IPv6 порты открыты.
Но ping между двумя устройствами не происходит.
Устройства успешно получают списки IP адресов из сети.
Видно что устройства посылают друг другу пакеты "BOB-аутентификации IPv6", но ответа не получают.

После внесения исправлений "BOB-аутентификация IPv6" начала работать.
Ping начал работать успешно.

**Лог первого устройства:**
```
RPi-HA# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
PING 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p (2a00:1e88:43a4:4900::f9d) 56 data bytes
64 bytes from RPi-HA.lan (2a00:1e88:43a4:4900::f9d): icmp_seq=1 ttl=64 time=0.074 ms
64 bytes from RPi-HA.lan (2a00:1e88:43a4:4900::f9d): icmp_seq=2 ttl=64 time=0.084 ms
64 bytes from RPi-HA.lan (2a00:1e88:43a4:4900::f9d): icmp_seq=3 ttl=64 time=0.088 ms

rtt min/avg/max/mdev = 0.074/0.082/0.088/0.005 ms
rpi@RPi-HA ~> ping kmp0dz0aw57dmxynvka7mqy60eggedqvpcby9jregk3d9n2skt90.p2p
PING kmp0dz0aw57dmxynvka7mqy60eggedqvpcby9jregk3d9n2skt90.p2p (2a00:1e88:43a4:4900::192) 56 data bytes
64 bytes from rpi-v3.lan (2a00:1e88:43a4:4900::192): icmp_seq=1 ttl=64 time=2.27 ms
64 bytes from rpi-v3.lan (2a00:1e88:43a4:4900::192): icmp_seq=2 ttl=64 time=8.97 ms
64 bytes from rpi-v3.lan (2a00:1e88:43a4:4900::192): icmp_seq=3 ttl=64 time=8.43 ms
64 bytes from rpi-v3.lan (2a00:1e88:43a4:4900::192): icmp_seq=4 ttl=64 time=8.57 ms
```

**Лог второго устройства:**

```
root@rpi-v3 /o/hspro (master)# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
root@rpi-v3 /o/hspro (master)# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
root@rpi-v3 /o/hspro (master)# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
root@rpi-v3 /o/hspro (master)# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
root@rpi-v3 /o/hspro (master)#
root@rpi-v3 /o/hspro (master)# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
ping: 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p: Name or service not known
root@rpi-v3 /o/hspro (master) [2]# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
ping: 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p: Name or service not known
root@rpi-v3 /o/hspro (master) [2]# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
ping: 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p: Name or service not known
root@rpi-v3 /o/hspro (master) [2]# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
ping: 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p: Name or service not known
root@rpi-v3 /o/hspro (master) [2]# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
ping: 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p: Name or service not known
root@rpi-v3 /o/hspro (master) [2]# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
PING 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p(RPi-HA.lan (2a00:1e88:43a4:4900::f9d)) 56 data bytes
64 bytes from RPi-HA.lan (2a00:1e88:43a4:4900::f9d): icmp_seq=1 ttl=64 time=6.57 ms
64 bytes from RPi-HA.lan (2a00:1e88:43a4:4900::f9d): icmp_seq=2 ttl=64 time=5.58 ms
64 bytes from RPi-HA.lan (2a00:1e88:43a4:4900::f9d): icmp_seq=3 ttl=64 time=7.59 ms
64 bytes from RPi-HA.lan (2a00:1e88:43a4:4900::f9d): icmp_seq=4 ttl=64 time=7.70 ms
```

Как видно из логов, адрес не скачивается из сети мнгновенно. Но после 10-30 секунд  адрес появляется в таблице, "BOB-аутентификация IPv6" проходит успешно, и ping начинает работать.

---


### Результат

После исправления IPv6 стал проходить BOB-аутентификацию.


