### PR TITLE
ext-bob: Fixed family-specific DHT sockets for BOB challenges

### DIFF
--- a/src/ext-bob.c
+++ b/src/ext-bob.c
@@ -538,7 +538,13 @@ static void bob_encrypt_challenge(int sock, uint8_t buf[], size_t buflen, IP *ad
     }
 }
 
+// BOB handler on the DHT socket: auth packets and periodic challenge sending.
+//
 // Called when traffic on the DHT port arrives.
+// Without traffic, called once per second:
+//   `bob_handler(sock, buf, buflen, &from)` with `buflen == 0`.
+//
+// Call chain: `net_loop() -> poll(1000 ms) -> dht_handler -> bob_handler`.
 bool bob_handler(int fd, uint8_t buf[], uint32_t buflen, IP *from)
 {
     if (buflen > 3 && memcmp(buf, "BOB", 3) == 0) {

--- a/src/ext-bob.c
+++ b/src/ext-bob.c
@@ -20,6 +20,7 @@
 #include "conf.h"
 #include "log.h"
 #include "utils.h"
+#include "kad.h"
 #include "announces.h"
 #include "searches.h"
 #include "ext-bob.h"
@@ -60,12 +61,11 @@ struct key_t {
 struct bob_resource {
     mbedtls_pk_context ctx_verify;
     uint8_t challenge[32];
-    uint8_t challenges_send;
+    uint8_t challenges_send; // Send attempts (successful and failed)
     char query[QUERY_MAX_SIZE];
     IP address;
 };
 
-static int g_dht_socket = -1;
 static struct key_t *g_keys = NULL;
 static time_t g_send_challenges = 0;
 static struct bob_resource g_bob_resources[8] = {0};
@@ -133,6 +133,22 @@ static struct bob_resource *bob_next_free_resource(void)
     return NULL;
 }
 
+static int bob_get_socket_by_family(const IP *addr)
+{
+    if (addr == NULL) {
+        return -1;
+    }
+
+    switch (addr->ss_family) {
+    case AF_INET:
+        return kad_get_dht_socket4();
+    case AF_INET6:
+        return kad_get_dht_socket6();
+    default:
+        return -1;
+    }
+}
+
 static void bob_send_challenge(int sock, struct bob_resource *resource)
 {
     uint8_t buf[3 + ECPARAMS_SIZE + CHALLENGE_BIN_LENGTH];
@@ -156,7 +172,10 @@ static void bob_send_challenge(int sock, struct bob_resource *resource)
         resource->challenges_send
     );
 
-    sendto(sock, buf, sizeof(buf), 0, (struct sockaddr*) &resource->address, sizeof(IP));
+    if (sendto(sock, buf, sizeof(buf), 0, (struct sockaddr*) &resource->address, addr_len(&resource->address)) < 0) {
+        log_debug("BOB: Failed to send auth challenge to %s (try %d), errno: %s",
+            str_addr(&resource->address), resource->challenges_send, strerror(errno));
+    }
 }
 
 // Start auth procedure for result bucket and utilize all resources
@@ -221,7 +240,7 @@ void bob_trigger_auth(void)
 
         resource->challenges_send = 0;
         bytes_random(resource->challenge, CHALLENGE_BIN_LENGTH);
-        bob_send_challenge(g_dht_socket, resource);
+        bob_send_challenge(bob_get_socket_by_family(&resource->address), resource);
     }
 }
 
@@ -403,7 +422,7 @@ bool bob_load_key(const char path[])
 }
 
 // Send challenges
-static void bob_send_challenges(int sock)
+static void bob_send_challenges(void)
 {
     struct bob_resource *resource;
 
@@ -416,7 +435,7 @@ static void bob_send_challenges(int sock)
         }
 
         if (resource->challenges_send < MAX_AUTH_CHALLENGE_SEND) {
-            bob_send_challenge(sock, resource);
+            bob_send_challenge(bob_get_socket_by_family(&resource->address), resource);
         } else {
             log_debug("BOB: Number of challenges exhausted for query: %s\n", resource->query);
             bob_auth_end(resource, AUTH_ERROR);
@@ -446,7 +465,11 @@ static void bob_verify_challenge(int sock, uint8_t buf[], size_t buflen, IP *add
         int ret = mbedtls_ecdsa_read_signature(mbedtls_pk_ec(resource->ctx_verify),
             resource->challenge, CHALLENGE_BIN_LENGTH, buf + 3, buflen - 3);
 
-        log_debug("BOB: Received response from %s does not verify: %s", str_addr(address), resource->query);
+        if (ret != 0) {
+            log_debug("BOB: Received response from %s does not verify: %s", str_addr(address), resource->query);
+        } else {
+            log_debug("BOB: Received response from %s verifies OK: %s", str_addr(address), resource->query);
+        }
         bob_auth_end(resource, ret ? AUTH_FAILED : AUTH_OK);
     } else {
         log_warning("BOB: No session found for address %s", str_addr(address));
@@ -502,7 +525,11 @@ static void bob_encrypt_challenge(int sock, uint8_t buf[], size_t buflen, IP *ad
             log_warning("mbedtls_ecdsa_write_signature returned %d\n", ret);
         } else {
             log_debug("Received challenge from %s and send back response", str_addr(address));
-            sendto(sock, sig, slen, 0, (struct sockaddr*) address, sizeof(IP));
+
+            if (sendto(sock, sig, slen, 0, (struct sockaddr*) address, addr_len(address)) < 0) {
+                log_warning("BOB: Failed to send challenge response to %s, errno: %s",
+                    str_addr(address), strerror(errno));
+            }
         }
     } else {
         log_debug("BOB: Secret key not found for public key: %s",
@@ -514,11 +541,6 @@ static void bob_encrypt_challenge(int sock, uint8_t buf[], size_t buflen, IP *ad
 // Called when traffic on the DHT port arrives.
 bool bob_handler(int fd, uint8_t buf[], uint32_t buflen, IP *from)
 {
-    // Hack to get the DHT socket..
-    if (g_dht_socket == -1) {
-        g_dht_socket = fd;
-    }
-
     if (buflen > 3 && memcmp(buf, "BOB", 3) == 0) {
         if (buflen == (3 + ECPARAMS_SIZE + CHALLENGE_BIN_LENGTH)) {
             // Answer a challenge request
@@ -535,7 +557,7 @@ bool bob_handler(int fd, uint8_t buf[], uint32_t buflen, IP *from)
     // Send out new challenges every second
     if (g_send_challenges < now) {
         g_send_challenges = now + 1;
-        bob_send_challenges(fd);
+        bob_send_challenges();
     }
 
     return false;

--- a/src/kad.c
+++ b/src/kad.c
@@ -32,6 +32,16 @@ static time_t g_dht_maintenance = 0;
 static int g_dht_socket4 = -1;
 static int g_dht_socket6 = -1;
 
+int kad_get_dht_socket4(void)
+{
+    return g_dht_socket4;
+}
+
+int kad_get_dht_socket6(void)
+{
+    return g_dht_socket6;
+}
+
 
 /*
 * Put an address and port into a sockaddr_storages struct.

--- a/src/kad.h
+++ b/src/kad.h
@@ -13,6 +13,11 @@
 bool kad_setup(void);
 void kad_free(void);
 
+// Get DHT UDP sockets (bound in kad_setup()).
+// Returns -1 if socket for the requested family is unavailable.
+int kad_get_dht_socket4(void);
+int kad_get_dht_socket6(void);
+
 // Ping this node to add it to the node table
 bool kad_ping(const IP *addr);
 

--- a/src/net.c
+++ b/src/net.c
@@ -99,6 +99,11 @@ void net_loop(void)
     }
 
     while (gconf->is_running) {
+        // Poll timeout (1000 ms) drives the event loop:
+        // - wakes the event loop at least once per second, even without fd events;
+        // - drives `call_all` below, which invokes callbacks with `revents == 0`;
+        // - used by periodic handlers such as `dht_handler()` and
+        //   `bob_handler()` challenge sending.
         int rc = poll(g_fds, g_count, 1000);
 
         if (rc < 0) {


### PR DESCRIPTION
### Summary

[Bug: IPv6 BOB authentication fails on dual-stack nodes · Issue #155 · mwarning/KadNode](https://github.com/mwarning/KadNode/issues/155)

**Symptom:** resolving `<pubkey>.p2p` didn’t return an `AAAA` record, even though the announcement was present in the DHT and the IPv6 address was reachable locally.

On dual-stack nodes, IPv6 `.p2p` resolution can fail even when the IPv6 address is published in the DHT and is reachable.

The issue is related to dual-stack operation. 

KadNode uses separate UDP sockets for IPv4 and IPv6 DHT traffic.
But BOB authentication appears to reuse a single remembered DHT socket (`g_dht_socket`). 

If that remembered socket is the IPv4 socket, IPv6 BOB challenges be sent through the wrong socket family.


### What exactly was fixed (how we fixed it)

**Fix idea:** 

There was one internal variable `g_dht_socket` used to send packets both for IPv4 (works) and for IPv6 (doesn’t, of course).

Since it was a single socket shared across two different protocol families, IPv6 didn’t work because it requires a separate socket.

BOB now always chooses the UDP socket **by the destination address family** (IPv4 → IPv4 DHT socket, IPv6 → IPv6 DHT socket), so success no longer depends on which `fd` (IPv4/IPv6) happened to reach the handler first.


Changes:

- **Export DHT sockets from `kad.c`:**
  - Added getters in `kadnode_src/src/kad.h` and implemented them in `kadnode_src/src/kad.c`:
    - `kad_get_dht_socket4()`
    - `kad_get_dht_socket6()`

- **Removed the `g_dht_socket` hack in `kadnode_src/src/ext-bob.c`:**
  - Added socket selection `bob_get_socket_by_family(const IP *addr)` -> grabs the correct FD via `kad_get_dht_socket4/6()`.
  - `bob_trigger_auth()` and retries use the **correct** socket for each resource (IPv4/IPv6).

- **Correct UDP sending:**
  - Added `sendto()` error checking and `errno` logging.
  - In `sendto()`, we use `addr_len(...)` instead of `sizeof(IP)` (for both the challenge and the reply).

---

### Verification

#### Before

There are two dual-stack devices (IPv4 + IPv6). KadNode is installed on both. IPv6 ports are open.

But ping between the two devices doesn’t happen.

The devices successfully fetch lists of IP addresses from the network.

You can see that they send each other “IPv6 BOB authentication” packets, but they don’t get any response.

#### After

After applying the fix, “IPv6 BOB authentication” started working.

Ping began working successfully.

**Log from the first device:**
```
RPi-HA# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
PING 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p (2a00:1e88:43a4:4900::f9d) 56 data bytes
64 bytes from RPi-HA.lan (2a00:1e88:43a4:4900::f9d): icmp_seq=1 ttl=64 time=0.074 ms
64 bytes from RPi-HA.lan (2a00:1e88:43a4:4900::f9d): icmp_seq=2 ttl=64 time=0.084 ms
64 bytes from RPi-HA.lan (2a00:1e88:43a4:4900::f9d): icmp_seq=3 ttl=64 time=0.088 ms

rtt min/avg/max/mdev = 0.074/0.082/0.088/0.005 ms
rpi@RPi-HA ~> ping kmp0dz0aw57dmxynvka7mqy60eggedqvpcby9jregk3d9n2skt90.p2p
PING kmp0dz0aw57dmxynvka7mqy60eggedqvpcby9jregk3d9n2skt90.p2p (2a00:1e88:43a4:4900::192) 56 data bytes
64 bytes from rpi-v3.lan (2a00:1e88:43a4:4900::192): icmp_seq=1 ttl=64 time=2.27 ms
64 bytes from rpi-v3.lan (2a00:1e88:43a4:4900::192): icmp_seq=2 ttl=64 time=8.97 ms
64 bytes from rpi-v3.lan (2a00:1e88:43a4:4900::192): icmp_seq=3 ttl=64 time=8.43 ms
64 bytes from rpi-v3.lan (2a00:1e88:43a4:4900::192): icmp_seq=4 ttl=64 time=8.57 ms
```

**Log from the second device:**

```
root@rpi-v3 /o/hspro (master)# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
root@rpi-v3 /o/hspro (master)# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
root@rpi-v3 /o/hspro (master)# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
root@rpi-v3 /o/hspro (master)# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
root@rpi-v3 /o/hspro (master)#
root@rpi-v3 /o/hspro (master)# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
ping: 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p: Name or service not known
root@rpi-v3 /o/hspro (master) [2]# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
ping: 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p: Name or service not known
root@rpi-v3 /o/hspro (master) [2]# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
ping: 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p: Name or service not known
root@rpi-v3 /o/hspro (master) [2]# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
ping: 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p: Name or service not known
root@rpi-v3 /o/hspro (master) [2]# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
ping: 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p: Name or service not known
root@rpi-v3 /o/hspro (master) [2]# ping 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p
PING 1mjtf5y4pyf8rm7zxjzp48k3p784ad1cv8h1v2fhwgp30qzy2v80.p2p(RPi-HA.lan (2a00:1e88:43a4:4900::f9d)) 56 data bytes
64 bytes from RPi-HA.lan (2a00:1e88:43a4:4900::f9d): icmp_seq=1 ttl=64 time=6.57 ms
64 bytes from RPi-HA.lan (2a00:1e88:43a4:4900::f9d): icmp_seq=2 ttl=64 time=5.58 ms
64 bytes from RPi-HA.lan (2a00:1e88:43a4:4900::f9d): icmp_seq=3 ttl=64 time=7.59 ms
64 bytes from RPi-HA.lan (2a00:1e88:43a4:4900::f9d): icmp_seq=4 ttl=64 time=7.70 ms
```

As you can see from the logs, the address doesn’t get pulled from the network instantly. But after 10–30 seconds the address appears in the table, “IPv6 BOB authentication” succeeds, and ping starts working.

---


### Result

After the fix, BOB authentication over IPv6 started working properly.
